### PR TITLE
[fix][attachment] field id from attachments is deleted after migratio…

### DIFF
--- a/src/Kobo.ts
+++ b/src/Kobo.ts
@@ -326,7 +326,7 @@ export namespace Kobo {
       filename: string
       download_small_url: string
       question_xpath: string
-      id: number
+      uid: string
     }
   }
 }


### PR DESCRIPTION
…n, new field is uid (string format)